### PR TITLE
Added getTradabilityStatus parameter to GetSymbolsAsync method

### DIFF
--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiExchangeData.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiExchangeData.cs
@@ -38,7 +38,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
         #region Get Symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<IEnumerable<CoinbaseSymbol>>> GetSymbolsAsync(SymbolType? type = null, ContractExpiryType? expiryType = null, ExpiryStatus? expireStatus = null, bool? allProducts = null, IEnumerable<string>? symbols = null, int? limit = null, int? offset = null, CancellationToken ct = default)
+        public async Task<WebCallResult<IEnumerable<CoinbaseSymbol>>> GetSymbolsAsync(SymbolType? type = null, ContractExpiryType? expiryType = null, ExpiryStatus? expireStatus = null, bool? allProducts = null, IEnumerable<string>? symbols = null, bool getTradabilityStatus = false, int? limit = null, int? offset = null, CancellationToken ct = default)
         {
             var parameters = new ParameterCollection();
             parameters.AddOptionalEnum("product_type", type);
@@ -50,8 +50,10 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
             if (!_baseClient.Authenticated)
                 request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v3/brokerage/market/products", CoinbaseExchange.RateLimiter.CoinbaseRestPublic, 1, false);
             else
+            {
+                parameters.Add("get_tradability_status", getTradabilityStatus);
                 request = _definitions.GetOrCreate(HttpMethod.Get, "/api/v3/brokerage/products", CoinbaseExchange.RateLimiter.CoinbaseRestPrivate, 1, true);
-            
+            }
             var result = await _baseClient.SendAsync<CoinbaseSymbolWrapper>(request, parameters, ct).ConfigureAwait(false);
             return result.As<IEnumerable<CoinbaseSymbol>>(result.Data?.Symbols);
         }
@@ -91,7 +93,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
                 request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v3/brokerage/market/product_book", CoinbaseExchange.RateLimiter.CoinbaseRestPublic, 1, false);
             else
                 request = _definitions.GetOrCreate(HttpMethod.Get, $"/api/v3/brokerage/product_book", CoinbaseExchange.RateLimiter.CoinbaseRestPrivate, 1, true);
-            
+
             var result = await _baseClient.SendAsync<CoinbaseOrderBookWrapper>(request, parameters, ct).ConfigureAwait(false);
             return result.As<CoinbaseOrderBook>(result.Data?.Book);
         }
@@ -159,7 +161,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
 
             if (!result.Data.Data.Any())
                 return result.AsError<CoinbaseBookTicker>(new ServerError("Not found"));
-            
+
             return result.As(result.Data.Data.Single());
         }
 

--- a/Coinbase.Net/Coinbase.Net.xml
+++ b/Coinbase.Net/Coinbase.Net.xml
@@ -160,7 +160,7 @@
         <member name="M:Coinbase.Net.Clients.AdvancedTradeApi.CoinbaseRestClientAdvancedTradeApiExchangeData.GetServerTimeAsync(System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
-        <member name="M:Coinbase.Net.Clients.AdvancedTradeApi.CoinbaseRestClientAdvancedTradeApiExchangeData.GetSymbolsAsync(System.Nullable{Coinbase.Net.Enums.SymbolType},System.Nullable{Coinbase.Net.Enums.ContractExpiryType},System.Nullable{Coinbase.Net.Enums.ExpiryStatus},System.Nullable{System.Boolean},System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+        <member name="M:Coinbase.Net.Clients.AdvancedTradeApi.CoinbaseRestClientAdvancedTradeApiExchangeData.GetSymbolsAsync(System.Nullable{Coinbase.Net.Enums.SymbolType},System.Nullable{Coinbase.Net.Enums.ContractExpiryType},System.Nullable{Coinbase.Net.Enums.ExpiryStatus},System.Nullable{System.Boolean},System.Collections.Generic.IEnumerable{System.String},System.Boolean,System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="M:Coinbase.Net.Clients.AdvancedTradeApi.CoinbaseRestClientAdvancedTradeApiExchangeData.GetSymbolAsync(System.String,System.Threading.CancellationToken)">
@@ -1845,7 +1845,7 @@
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
-        <member name="M:Coinbase.Net.Interfaces.Clients.AdvancedTradeApi.ICoinbaseRestClientAdvancedTradeApiExchangeData.GetSymbolsAsync(System.Nullable{Coinbase.Net.Enums.SymbolType},System.Nullable{Coinbase.Net.Enums.ContractExpiryType},System.Nullable{Coinbase.Net.Enums.ExpiryStatus},System.Nullable{System.Boolean},System.Collections.Generic.IEnumerable{System.String},System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+        <member name="M:Coinbase.Net.Interfaces.Clients.AdvancedTradeApi.ICoinbaseRestClientAdvancedTradeApiExchangeData.GetSymbolsAsync(System.Nullable{Coinbase.Net.Enums.SymbolType},System.Nullable{Coinbase.Net.Enums.ContractExpiryType},System.Nullable{Coinbase.Net.Enums.ExpiryStatus},System.Nullable{System.Boolean},System.Collections.Generic.IEnumerable{System.String},System.Boolean,System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
             <summary>
             Get list of supported symbols
             <para><a href="https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getpublicproducts" /></para>
@@ -1855,6 +1855,7 @@
             <param name="expireStatus">Status of futures expiry status</param>
             <param name="allProducts">Return all symbols</param>
             <param name="symbols">Filter by symbol names</param>
+            <param name="getTradabilityStatus">Whether or not to populate <see cref="P:Coinbase.Net.Objects.Models.CoinbaseSymbol.ViewOnly"/> with the tradability status of the product. This is only enabled for SPOT products. Can only be used when the client is authenticated.</param>
             <param name="limit">Max number of resulst</param>
             <param name="offset">Result offset</param>
             <param name="ct">Cancellation token</param>

--- a/Coinbase.Net/Interfaces/Clients/AdvancedTradeApi/ICoinbaseRestClientAdvancedTradeApiExchangeData.cs
+++ b/Coinbase.Net/Interfaces/Clients/AdvancedTradeApi/ICoinbaseRestClientAdvancedTradeApiExchangeData.cs
@@ -29,10 +29,11 @@ namespace Coinbase.Net.Interfaces.Clients.AdvancedTradeApi
         /// <param name="expireStatus">Status of futures expiry status</param>
         /// <param name="allProducts">Return all symbols</param>
         /// <param name="symbols">Filter by symbol names</param>
+        /// <param name="getTradabilityStatus">Whether or not to populate <see cref="CoinbaseSymbol.ViewOnly"/> with the tradability status of the product. This is only enabled for SPOT products. Can only be used when the client is authenticated.</param>
         /// <param name="limit">Max number of resulst</param>
         /// <param name="offset">Result offset</param>
         /// <param name="ct">Cancellation token</param>
-        Task<WebCallResult<IEnumerable<CoinbaseSymbol>>> GetSymbolsAsync(SymbolType? type = null, ContractExpiryType? expiryType = null, ExpiryStatus? expireStatus = null, bool? allProducts = null, IEnumerable<string>? symbols = null, int? limit = null, int? offset = null, CancellationToken ct = default);
+        Task<WebCallResult<IEnumerable<CoinbaseSymbol>>> GetSymbolsAsync(SymbolType? type = null, ContractExpiryType? expiryType = null, ExpiryStatus? expireStatus = null, bool? allProducts = null, IEnumerable<string>? symbols = null, bool getTradabilityStatus = false, int? limit = null, int? offset = null, CancellationToken ct = default);
 
         /// <summary>
         /// Get info on a specific symbol


### PR DESCRIPTION
Added getTradabilityStatus to the GetSymbolsAsync method. This is a parameter that can only be used for the authenticated endpoint to determine which symbols are ViewOnly for the current account.
https://docs.cdp.coinbase.com/advanced-trade/reference/retailbrokerageapi_getproducts