### PR TITLE
Added AssetMigration type to TransactionType enum

### DIFF
--- a/Coinbase.Net/Coinbase.Net.xml
+++ b/Coinbase.Net/Coinbase.Net.xml
@@ -3104,6 +3104,11 @@
             Interest payout
             </summary>
         </member>
+        <member name="F:Coinbase.Net.Enums.TransactionType.AssetMigration">
+            <summary>
+            Asset migration
+            </summary>
+        </member>
         <member name="T:Coinbase.Net.Enums.TriggerStatus">
             <summary>
             Trigger status

--- a/Coinbase.Net/Enums/TransactionType.cs
+++ b/Coinbase.Net/Enums/TransactionType.cs
@@ -149,6 +149,11 @@ namespace Coinbase.Net.Enums
         /// Interest payout
         /// </summary>
         [Map("interest")]
-        Interest
+        Interest,
+        /// <summary>
+        /// Asset migration
+        /// </summary>
+        [Map("asset_migration")]
+        AssetMigration
     }
 }


### PR DESCRIPTION
Added a new type (`AssetMigration`) to the `TransactionType` enum. This type was used, for example, during the migration from MATIC to POL (https://help.coinbase.com/en/coinbase/trading-and-funding/sending-or-receiving-cryptocurrency/polygon-migration)