### PR TITLE
Updated CoinbaseSymbolPerpDetails FundingRate to nullable decimal

### DIFF
--- a/Coinbase.Net/Objects/Models/CoinbaseSymbol.cs
+++ b/Coinbase.Net/Objects/Models/CoinbaseSymbol.cs
@@ -336,7 +336,7 @@ namespace Coinbase.Net.Objects.Models
         /// ["<c>funding_rate</c>"] Funding rate
         /// </summary>
         [JsonPropertyName("funding_rate")]
-        public decimal FundingRate { get; set; }
+        public decimal? FundingRate { get; set; }
         /// <summary>
         /// ["<c>funding_time</c>"] Funding time
         /// </summary>


### PR DESCRIPTION
Fix for this error:

```log
[] Json deserialization failed: The JSON value could not be converted to System.Decimal. Path: $.products[152].future_product_details.perpetual_details.funding_rate | LineNumber: 0 | BytePositionInLine: 399128., Path: $.products[152].future_product_details.perpetual_details.funding_rate, LineNumber: 0, LinePosition: 399128
 ---> System.Text.Json.JsonException: The JSON value could not be converted to System.Decimal. Path: $.products[152].future_product_details.perpetual_details.funding_rate | LineNumber: 0 | BytePositionInLine: 399128.
 ---> System.FormatException: The JSON value is either too large or too small for a Decimal.
   at System.Text.Json.ThrowHelper.ThrowFormatException(NumericType numericType)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---
   at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& state, Utf8JsonReader& reader, Exception ex)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.DeserializeAsync[TReadBufferState,TStream](TStream utf8Json, TReadBufferState bufferState, CancellationToken cancellationToken)
   at CryptoExchange.Net.Converters.SystemTextJson.MessageHandlers.JsonRestMessageHandler.TryDeserializeAsync[T](Stream responseStream, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
...
```