### PR TITLE
Updated AuthenticationProvider token creation

### DIFF
--- a/Coinbase.Net/CoinbaseAuthenticationProvider.cs
+++ b/Coinbase.Net/CoinbaseAuthenticationProvider.cs
@@ -53,15 +53,15 @@ namespace Coinbase.Net
 
             var descriptor = new SecurityTokenDescriptor
             {
-                Issuer = "coinbase-cloud",
+                Issuer = "cdp",
                 NotBefore = timestamp,
-                Expires = timestamp.AddMinutes(1),
+                Expires = timestamp.AddMinutes(2),
                 Claims = new Dictionary<string, object> {
                     { "sub", Credential.Key }
                 },
                 AdditionalHeaderClaims = new Dictionary<string, object>
                 {
-                    { "nonce", BytesToHexString(nonce) },
+                    { "nonce", BytesToHexString(nonce).ToLowerInvariant() },
                     { "typ", "JWT" }
                 },
                 SigningCredentials = _signingCreds
@@ -70,7 +70,7 @@ namespace Coinbase.Net
             if (uriLine != null)
                 descriptor.Claims.Add("uri", uriLine);
 
-            var result = new JsonWebTokenHandler().CreateToken(descriptor);
+            var result = new JsonWebTokenHandler { SetDefaultTimesOnTokenCreation = false }.CreateToken(descriptor);
             return result;
 #else
             throw new PlatformNotSupportedException("Authentication is not available for .NetStandard2.0 due to platform limitations");


### PR DESCRIPTION
I had a problem where my test API credentials weren't working, even though other credentials worked.
Error message: `[Unauthorized] Deserialization failed, invalid JSON: Unauthorized`

Although it’s set up as shown in the C# example on the official site (https://docs.cdp.coinbase.com/coinbase-app/authentication-authorization/api-key-authentication#c%23), this differs from all the other examples there (Python, Javascript, etc). The official Python SDK also works differently (https://github.com/coinbase/coinbase-advanced-py/blob/master/coinbase/jwt_generator.py).

Accordingly, I adjusted the logic. It is now implemented like all the other examples. With the following fix, everything now works - my test credentials as well as all the others I am using. 

