### PR TITLE
Shared asset types

### DIFF
--- a/Coinbase.Net.UnitTests/Endpoints/AdvancedTrade/ExchangeData/GetSymbols.txt
+++ b/Coinbase.Net.UnitTests/Endpoints/AdvancedTrade/ExchangeData/GetSymbols.txt
@@ -64,7 +64,7 @@ false
         "funding_time": "1727686200",
         "max_leverage": "1",
         "base_asset_uuid": "string",
-        "underlying_type": "string"
+        "underlying_type": "EQUITY"
       },
       "contract_display_name": "string",
       "time_to_expiry_ms": "1727686200",

--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
@@ -454,7 +454,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
         #endregion
 
         #region Spot Symbol client
-        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicSpotId, EnvironmentName, null);
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicSpotId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -951,7 +951,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
 
         #region Futures Symbol client
 
-        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicFuturesId, EnvironmentName, null);
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_exchangeName, _topicFuturesId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {

--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
@@ -26,6 +26,8 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
         public void ResetDefaultExchangeParameters() => ExchangeParameters.ResetStaticParameters();
         public SharedClientInfo Discover() => SharedUtils.GetClientInfo(CoinbaseExchange.Metadata, this);
 
+        private static readonly HashSet<string> _exchangeSupportedFiat = ["USD", "EUR", "GBP", "INR", "AUD", "CAD", "SGD"];
+
         #region Asset client
         GetAssetsOptions IAssetsRestClient.GetAssetsOptions { get; } = new GetAssetsOptions(_exchangeName, false);
 
@@ -452,6 +454,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
         #endregion
 
         #region Spot Symbol client
+        SharedSymbolCatalog? ISpotSymbolRestClient.SpotSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicSpotId, EnvironmentName, null);
         GetSpotSymbolsOptions ISpotSymbolRestClient.GetSpotSymbolsOptions { get; } = new GetSpotSymbolsOptions(_exchangeName, false);
 
         async Task<HttpResult<SharedSpotSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
@@ -468,20 +471,52 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
             // For example both BTC-USD and BTC-USDC is returned, referring to the same symbol
             // Also, when for example subscribing to BTC-USDC in update the name is BTC-USD instead
             // The library uses the BTC-USDC notation
-            var symbolData = result.Data.Select(s => new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.SymbolStatus == SymbolStatus.Online && !s.IsDisabled && !s.TradingDisabled)
+            var data = result.Data
+                .Select(x => ParseSpotSymbol(x))
+                .ToArray();
+
+            var resultData = data.Where(x => x.QuoteAsset != "USD").ToArray();
+            foreach (var item in data.Where(x => x.QuoteAsset == "USD"))
+                item.QuoteAsset = "USDC";
+
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(resultData, request));
+        }
+
+        private SharedSpotSymbol ParseSpotSymbol(CoinbaseSymbol s)
+        {
+            var result = new SharedSpotSymbol(s.BaseAsset, s.QuoteAsset, s.Symbol, s.SymbolStatus == SymbolStatus.Online && !s.IsDisabled && !s.TradingDisabled)
             {
                 MinTradeQuantity = s.MinOrderQuantity,
                 MaxTradeQuantity = s.MaxOrderQuantity,
                 QuantityStep = s.QuantityStep,
-                PriceStep = s.PriceStep
-            }).ToArray();
+                PriceStep = s.PriceStep,
+                DisplayName = s.DisplayName
+            };
 
-            var originalSymbols = symbolData.Where(x => x.QuoteAsset != "USD").ToArray();
-            foreach (var item in symbolData.Where(x => x.QuoteAsset == "USD"))            
-                item.QuoteAsset = "USDC";            
+            if (_exchangeSupportedFiat.Contains(s.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                if (LibraryHelpers.IsStableCoin(s.QuoteAsset))
+                    result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicSpotId, EnvironmentName, null, symbolData);
-            return HttpResult.Ok(result, originalSymbols);
+            if (_exchangeSupportedFiat.Contains(s.BaseAsset))
+            {
+                result.BaseAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.BaseAssetType = SharedAssetType.Crypto;
+                if (LibraryHelpers.IsStableCoin(s.BaseAsset))
+                    result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+            }
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> ISpotSymbolRestClient.GetSpotSymbolsForBaseAssetAsync(string baseAsset)
@@ -916,6 +951,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
 
         #region Futures Symbol client
 
+        SharedSymbolCatalog? IFuturesSymbolRestClient.FuturesSymbolCatalog => ExchangeSymbolCache.GetSymbolCatalog(_topicFuturesId, EnvironmentName, null);
         GetFuturesSymbolsOptions IFuturesSymbolRestClient.GetFuturesSymbolsOptions { get; } = new GetFuturesSymbolsOptions(_exchangeName, false);
         async Task<HttpResult<SharedFuturesSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsAsync(GetSymbolsRequest request, CancellationToken ct)
         {
@@ -924,33 +960,103 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
                 return HttpResult.Fail<SharedFuturesSymbol[]>(Exchange, validationError);
 
             var expiringTime = request.TradingMode == null || request.TradingMode == TradingMode.PerpetualLinear ? ContractExpiryType.Perpetual : ContractExpiryType.Expiring;
-            var resultTicker = await ExchangeData.GetSymbolsAsync(SymbolType.Futures, expiryType: expiringTime, ct: ct).ConfigureAwait(false);
-            if (!resultTicker.Success)
-                return HttpResult.Fail<SharedFuturesSymbol[]>(resultTicker);
+            var result = await ExchangeData.GetSymbolsAsync(SymbolType.Futures, expiryType: expiringTime, ct: ct).ConfigureAwait(false);
+            if (!result.Success)
+                return HttpResult.Fail<SharedFuturesSymbol[]>(result);
 
-            var data = resultTicker.Data;
+            var data = result.Data
+                .Select(x => ParseFuturesSymbol(x))
+                .ToArray();
 
-            var response = HttpResult.Ok(resultTicker,
-                data.Select(x =>
-                    new SharedFuturesSymbol(
-                        x.FutureProductDetails!.ContractExpiry == null ? TradingMode.PerpetualLinear: TradingMode.DeliveryLinear,
+            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, expiringTime.ToString(), data);
+            return HttpResult.Ok(result, SharedUtils.ApplySymbolFilter(data, request));
+        }
+
+        private SharedFuturesSymbol ParseFuturesSymbol(CoinbaseSymbol x)
+        {
+            var result = new SharedFuturesSymbol(
+                        x.FutureProductDetails!.ContractExpiry == null ? TradingMode.PerpetualLinear : TradingMode.DeliveryLinear,
                         x.FutureProductDetails.ContractCode,
                         x.QuoteAsset,
                         x.Symbol,
                         x.SymbolStatus == SymbolStatus.Online && !x.IsDisabled && !x.TradingDisabled)
-                    {
-                        MinTradeQuantity = x.MinOrderQuantity,
-                        MaxTradeQuantity = x.MaxOrderQuantity,
-                        QuantityStep = x.QuantityStep,
-                        PriceStep = x.PriceStep,
-                        ContractSize = x.FutureProductDetails.ContractSize,
-                        DeliveryTime = x.FutureProductDetails.ContractExpiry,
-                        MaxLongLeverage = x.FutureProductDetails.PerpetualDetails?.MaxLeverage,
-                        MaxShortLeverage = x.FutureProductDetails.PerpetualDetails?.MaxLeverage
-                    }).ToArray());
+            {
+                MinTradeQuantity = x.MinOrderQuantity,
+                MaxTradeQuantity = x.MaxOrderQuantity,
+                QuantityStep = x.QuantityStep,
+                PriceStep = x.PriceStep,
+                ContractSize = x.FutureProductDetails.ContractSize,
+                DeliveryTime = x.FutureProductDetails.ContractExpiry,
+                MaxLongLeverage = x.FutureProductDetails.PerpetualDetails?.MaxLeverage,
+                MaxShortLeverage = x.FutureProductDetails.PerpetualDetails?.MaxLeverage,
+                DisplayName = x.DisplayName
+            };
 
-            ExchangeSymbolCache.UpdateSymbolInfo(_topicFuturesId, EnvironmentName, null, response.Data!);
-            return response;
+            if (_exchangeSupportedFiat.Contains(x.QuoteAsset))
+            {
+                result.QuoteAssetType = SharedAssetType.Fiat;
+            }
+            else
+            {
+                result.QuoteAssetType = SharedAssetType.Crypto;
+                if (LibraryHelpers.IsStableCoin(x.QuoteAsset))
+                    result.QuoteAssetSubType = SharedAssetSubType.StableCoin;
+            }
+
+            if (x.FutureProductDetails == null)
+            {
+                // Shouldn't be null for futures symbols, but just in case
+                result.BaseAssetType = SharedAssetType.Unspecified;
+            }
+            else
+            {
+                if (result.TradingMode.IsPerpetual())
+                {
+                    if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Equity
+                        || x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.EquityEtf)
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    }
+                    else if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Commodity)
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                    }
+                    else if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Index)
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Index;
+                    }
+                    else
+                    {
+                        result.BaseAssetType = SharedAssetType.Crypto;
+                        if (LibraryHelpers.IsStableCoin(x.BaseAsset))
+                            result.BaseAssetSubType = SharedAssetSubType.StableCoin;
+                    }
+                }
+                else
+                {
+                    if (x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Stocks)
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                    }
+                    else if (x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Energy
+                        || x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Metals)
+                    {
+                        result.BaseAssetType = SharedAssetType.TradFi;
+                        result.BaseAssetSubType = SharedAssetSubType.Commodity;
+                    }
+                    else
+                    {
+                        result.BaseAssetType = SharedAssetType.Crypto;
+                    }
+                }
+            }
+
+
+            return result;
         }
 
         async Task<ExchangeCallResult<SharedSymbol[]>> IFuturesSymbolRestClient.GetFuturesSymbolsForBaseAssetAsync(string baseAsset)

--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
@@ -1013,20 +1013,16 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
                 if (result.TradingMode.IsPerpetual())
                 {
                     if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Equity
-                        || x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.EquityEtf)
+                        || x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.EquityEtf
+                        || x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Index)
                     {
                         result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
                     }
                     else if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Commodity)
                     {
                         result.BaseAssetType = SharedAssetType.TradFi;
                         result.BaseAssetSubType = SharedAssetSubType.Commodity;
-                    }
-                    else if (x.FutureProductDetails.PerpetualDetails?.UnderlyingType == UnderlyingType.Index)
-                    {
-                        result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Index;
                     }
                     else
                     {
@@ -1040,7 +1036,7 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
                     if (x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Stocks)
                     {
                         result.BaseAssetType = SharedAssetType.TradFi;
-                        result.BaseAssetSubType = SharedAssetSubType.Stock;
+                        result.BaseAssetSubType = SharedAssetSubType.Equity;
                     }
                     else if (x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Energy
                         || x.FutureProductDetails.FuturesAssetType == FuturesAssetType.Metals)

--- a/Coinbase.Net/Coinbase.Net.csproj
+++ b/Coinbase.Net/Coinbase.Net.csproj
@@ -53,11 +53,13 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CryptoExchange.Net" Version="12.1.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Coinbase.Net/Coinbase.Net.csproj
+++ b/Coinbase.Net/Coinbase.Net.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
@@ -53,13 +53,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="CryptoExchange.Net" Version="12.2.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.101">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\CryptoExchange.Net\CryptoExchange.Net\CryptoExchange.Net.csproj" />
   </ItemGroup>
 </Project>

--- a/Coinbase.Net/Enums/FuturesAssetType.cs
+++ b/Coinbase.Net/Enums/FuturesAssetType.cs
@@ -1,0 +1,34 @@
+using System.Text.Json.Serialization;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Attributes;
+
+namespace Coinbase.Net.Enums
+{
+    /// <summary>
+    /// Futures asset type
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<FuturesAssetType>))]
+    public enum FuturesAssetType
+    {
+        /// <summary>
+        /// ["<c>FUTURES_ASSET_TYPE_METALS</c>"] Metals
+        /// </summary>
+        [Map("FUTURES_ASSET_TYPE_METALS")]
+        Metals,
+        /// <summary>
+        /// ["<c>FUTURES_ASSET_TYPE_CRYPTO</c>"] Crypto
+        /// </summary>
+        [Map("FUTURES_ASSET_TYPE_CRYPTO")]
+        Crypto,
+        /// <summary>
+        /// ["<c>FUTURES_ASSET_TYPE_STOCKS</c>"] Stocks
+        /// </summary>
+        [Map("FUTURES_ASSET_TYPE_STOCKS")]
+        Stocks,
+        /// <summary>
+        /// ["<c>FUTURES_ASSET_TYPE_ENERGY</c>"] Energy
+        /// </summary>
+        [Map("FUTURES_ASSET_TYPE_ENERGY")]
+        Energy
+    }
+}

--- a/Coinbase.Net/Enums/UnderlyingType.cs
+++ b/Coinbase.Net/Enums/UnderlyingType.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+using CryptoExchange.Net.Converters.SystemTextJson;
+using CryptoExchange.Net.Attributes;
+
+namespace Coinbase.Net.Enums
+{
+    /// <summary>
+    /// Underlying type
+    /// </summary>
+    [JsonConverter(typeof(EnumConverter<UnderlyingType>))]
+    public enum UnderlyingType
+    {
+        /// <summary>
+        /// ["<c>EQUITY</c>"] Equity
+        /// </summary>
+        [Map("EQUITY")]
+        Equity,
+        /// <summary>
+        /// ["<c>EQUITY</c>"] Equity ETF
+        /// </summary>
+        [Map("EQUITY_ETF")]
+        EquityEtf,
+        /// <summary>
+        /// ["<c>SPOT</c>"] Spot
+        /// </summary>
+        [Map("SPOT")]
+        Spot,
+        /// <summary>
+        /// ["<c>COMMOD</c>"] Commodity
+        /// </summary>
+        [Map("COMMOD")]
+        Commodity,
+        /// <summary>
+        /// ["<c>INDEX</c>"] Index
+        /// </summary>
+        [Map("INDEX")]
+        Index,
+        /// <summary>
+        /// ["<c>PREIPO</c>"] Pre-IPO
+        /// </summary>
+        [Map("PREIPO")]
+        PreIpo
+    }
+}

--- a/Coinbase.Net/Objects/Models/CoinbaseSymbol.cs
+++ b/Coinbase.Net/Objects/Models/CoinbaseSymbol.cs
@@ -324,6 +324,11 @@ namespace Coinbase.Net.Objects.Models
         /// </summary>
         [JsonPropertyName("index_price")]
         public decimal? IndexPrice { get; set; }
+        /// <summary>
+        /// ["<c>futures_asset_type</c>"] Asset type
+        /// </summary>
+        [JsonPropertyName("futures_asset_type")]
+        public FuturesAssetType FuturesAssetType { get; set; }
     }
 
     /// <summary>
@@ -361,6 +366,6 @@ namespace Coinbase.Net.Objects.Models
         /// ["<c>underlying_type</c>"] Underlying type
         /// </summary>
         [JsonPropertyName("underlying_type")]
-        public string? UnderlyingType { get; set; }
+        public UnderlyingType? UnderlyingType { get; set; }
     }
 }


### PR DESCRIPTION
Updated CryptoExchange.Net to v12.2.0 
Added SpotSymbolCatalog to Shared ISpotSymbolRestClient interface
Added FuturesSymbolCatalog to Shared IFuturesSymbolRestClient interface
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to GetSymbolsRequest model
Added DisplayName to SharedSpotSymbol and SharedFuturesSymbol models
Added BaseAssetType, BaseAssetSubType, QuoteAssetType and QuoteAssetSubType to SharedSpotSymbol and SharedFuturesSymbol models
Added DebuggerDisplay attributes to Shared models
Added FuturesAssetType to CoinbaseSymbolFuturesDetails model
Updated UnderlyingType to Enum in CoinbaseSymbolPerpDetails model