### PR TITLE
Fix deserialization of the INTX perpetual balances response

### DIFF
--- a/Coinbase.Net.UnitTests/Endpoints/AdvancedTrade/Account/GetPerpetualBalances.txt
+++ b/Coinbase.Net.UnitTests/Endpoints/AdvancedTrade/Account/GetPerpetualBalances.txt
@@ -2,7 +2,8 @@ GET
 /api/v3/brokerage/intx/balances/123
 true
 {
-  "portfolio_balances": {
+  "portfolio_balances": [
+   {
     "portfolio_uuid": "string",
     "balances": [
       {
@@ -12,7 +13,7 @@ true
           "asset_name": "string",
           "status": "string",
           "collateral_weight": "123",
-          "account_collateral_limit": "123",
+          "account_collateral_limit": "",
           "ecosystem_collateral_limit_breached": true,
           "asset_icon_url": "string",
           "supported_networks_enabled": true
@@ -29,5 +30,6 @@ true
       }
     ],
     "is_margin_limit_reached": true
-  }
+   }
+  ]
 }

--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiAccount.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiAccount.cs
@@ -188,13 +188,13 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
         #region Get Perpetual Balances
 
         /// <inheritdoc />
-        public async Task<HttpResult<CoinbasePerpetualBalances>> GetPerpetualBalancesAsync(string portfolioId, CancellationToken ct = default)
+        public async Task<HttpResult<CoinbasePerpetualBalances[]>> GetPerpetualBalancesAsync(string portfolioId, CancellationToken ct = default)
         {
             var parameters = new Parameters(CoinbaseExchange._parameterSerializationSettings);
             var request = _definitions.GetOrCreate(HttpMethod.Get, _baseClient.BaseAddress, $"/api/v3/brokerage/intx/balances/{portfolioId}", CoinbaseExchange.RateLimiter.CoinbaseRestPrivate, 1, true);
             var result = await _baseClient.SendAsync<CoinbasePerpetualBalancesWrapper>(request, parameters, ct).ConfigureAwait(false);
             if (!result.Success)
-                return HttpResult.Fail<CoinbasePerpetualBalances>(result);
+                return HttpResult.Fail<CoinbasePerpetualBalances[]>(result);
 
             return HttpResult.Ok(result, result.Data.PortfolioBalances);
         }

--- a/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
+++ b/Coinbase.Net/Clients/AdvancedTradeApi/CoinbaseRestClientAdvancedTradeApiShared.cs
@@ -128,10 +128,17 @@ namespace Coinbase.Net.Clients.AdvancedTradeApi
                 if (!result.Success)
                     return HttpResult.Fail<SharedBalance[]>(result);
 
-                return HttpResult.Ok(result, result.Data.Balances.Select(x => 
+                // The endpoint answers with one entry per portfolio; take the requested one, falling
+                // back to the single entry a portfolio-scoped key returns without echoing its uuid.
+                var portfolio = result.Data.FirstOrDefault(x => x.PortfolioId == portfolioId)
+                    ?? result.Data.FirstOrDefault();
+                if (portfolio == null)
+                    return HttpResult.Ok(result, Array.Empty<SharedBalance>());
+
+                return HttpResult.Ok(result, portfolio.Balances.Select(x =>
                     new SharedBalance(
-                        TradingMode.PerpetualLinear, 
-                        x.Asset.AssetId, 
+                        TradingMode.PerpetualLinear,
+                        x.Asset.AssetId,
                         x.MaxWithdrawQuantity,
                         x.Quantity)).ToArray());
             }

--- a/Coinbase.Net/Interfaces/Clients/AdvancedTradeApi/ICoinbaseRestClientAdvancedTradeApiAccount.cs
+++ b/Coinbase.Net/Interfaces/Clients/AdvancedTradeApi/ICoinbaseRestClientAdvancedTradeApiAccount.cs
@@ -170,7 +170,7 @@ namespace Coinbase.Net.Interfaces.Clients.AdvancedTradeApi
         /// <param name="portfolioId">["<c>portfolioId</c>"] Portfolio uuid</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<HttpResult<CoinbasePerpetualBalances>> GetPerpetualBalancesAsync(string portfolioId, CancellationToken ct = default);
+        Task<HttpResult<CoinbasePerpetualBalances[]>> GetPerpetualBalancesAsync(string portfolioId, CancellationToken ct = default);
 
         /// <summary>
         /// Set multi asset collateral mode

--- a/Coinbase.Net/Objects/Models/CoinbasePerpetualBalances.cs
+++ b/Coinbase.Net/Objects/Models/CoinbasePerpetualBalances.cs
@@ -8,10 +8,10 @@ namespace Coinbase.Net.Objects.Models
     internal record CoinbasePerpetualBalancesWrapper
     {
         /// <summary>
-        /// ["<c>portfolio_balances</c>"] Portfolio balances
+        /// ["<c>portfolio_balances</c>"] Portfolio balances, one entry per portfolio
         /// </summary>
         [JsonPropertyName("portfolio_balances")]
-        public CoinbasePerpetualBalances PortfolioBalances { get; set; } = null!;
+        public CoinbasePerpetualBalances[] PortfolioBalances { get; set; } = Array.Empty<CoinbasePerpetualBalances>();
     }
 
     /// <summary>
@@ -127,10 +127,11 @@ namespace Coinbase.Net.Objects.Models
         [JsonPropertyName("collateral_weight")]
         public decimal CollateralWeight { get; set; }
         /// <summary>
-        /// ["<c>account_collateral_limit</c>"] Account collateral limit
+        /// ["<c>account_collateral_limit</c>"] Account collateral limit, null when the asset has none
+        /// (the API sends an empty string for it)
         /// </summary>
         [JsonPropertyName("account_collateral_limit")]
-        public decimal AccountCollateralLimit { get; set; }
+        public decimal? AccountCollateralLimit { get; set; }
         /// <summary>
         /// ["<c>ecosystem_collateral_limit_breached</c>"] Ecosystem collateral limit breached
         /// </summary>


### PR DESCRIPTION
**Title:** Fix deserialization of the INTX perpetual balances response

### What goes wrong

`GetPerpetualBalancesAsync` always fails against a live INTX portfolio:

```
Json deserialization failed: The JSON value could not be converted to
Coinbase.Net.Objects.Models.CoinbasePerpetualBalances.
Path: $.portfolio_balances | LineNumber: 0 | BytePositionInLine: 23.
```

The same failure takes out the shared API, because `GetBalancesAsync` routes
`PerpetualLinearFutures` / `PerpetualInverseFutures` through that call — so a
Coinbase perpetuals account cannot be read at all through either surface.

This is what `GET /api/v3/brokerage/intx/balances/{portfolio_uuid}` actually
returns (real response, uuid kept, icon url shortened):

```json
{"portfolio_balances":[{"portfolio_uuid":"019fc79d-2fd6-7b8e-9db5-5551033c7042",
 "balances":[{"asset":{"asset_id":"1","asset_uuid":"2b92315d-eab7-5bef-84fa-089a131333f5",
   "asset_name":"USDC","status":"ACTIVE","collateral_weight":"1",
   "account_collateral_limit":"","ecosystem_collateral_limit_breached":false,
   "asset_icon_url":"https://dynamic-assets.coinbase.com/…","supported_networks_enabled":false,
   "haircuts":null,"in_cross_collateral_pool":false},
  "quantity":"0","hold":"0","transfer_hold":"0","collateral_value":"0","collateral_weight":"1",
  "max_withdraw_amount":"0","loan":"0","loan_collateral_requirement_usd":"0.0",
  "pledged_quantity":"0","max_portfolio_transfer_amount":"0"}],
 "is_margin_limit_reached":false}]}
```

Two things differ from the model:

1. **`portfolio_balances` is an array**, one entry per portfolio — the wrapper
   declares it as a single `CoinbasePerpetualBalances`. Byte 23 in the error is
   exactly the `[`. Coinbase's published example still shows an object, which is
   also what the endpoint fixture in this repo contains, so the existing test
   could not catch it.
2. **`account_collateral_limit` can be an empty string** when the asset has no
   limit. It is modelled as a non-nullable `decimal`, and the library's global
   `DecimalConverter` (which maps `""` to null) only binds to `decimal?`, so
   parsing fails a second time once the array is handled:

```
The JSON value could not be converted to System.Decimal.
Path: $.portfolio_balances[0].balances[0].asset.account_collateral_limit
```

### How this fixes it

- `CoinbasePerpetualBalancesWrapper.PortfolioBalances` becomes
  `CoinbasePerpetualBalances[]`, matching the response.
- `GetPerpetualBalancesAsync` returns `HttpResult<CoinbasePerpetualBalances[]>`
  and hands back every entry the venue sent. This is a breaking signature
  change, and the alternative — silently returning the first entry — hides a
  multi-portfolio response from the caller.
- The shared balance client picks the entry whose `portfolio_uuid` matches the
  requested `PortfolioId`, falling back to the single entry (a portfolio-scoped
  API key gets exactly one back), and returns no balances rather than throwing
  if the array is empty.
- `CoinbasePerpetualBalancesAsset.AccountCollateralLimit` becomes `decimal?`, so
  the existing converter turns `""` into null.
- The `GetPerpetualBalances` endpoint fixture now carries the real shape,
  including the empty `account_collateral_limit`, so both regressions are
  covered by `RestRequestTests`.

### Verification

`Coinbase.Net.UnitTests` passes, and the change was confirmed against a live
INTX portfolio: the balance call that failed on every attempt now returns the
portfolio's balances and the account connects.

### One thing left alone

The shared mapping labels each balance with `x.Asset.AssetId`, which for this
response is `"1"` — `asset_name` holds `"USDC"`. That looks wrong for any
consumer displaying balances, but it is a separate behavioural change from the
parsing bug, so it is not part of this PR.
